### PR TITLE
チャットの非同期通信の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,9 +192,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -231,7 +228,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -59,10 +59,11 @@ $(function(){
       var html = buildHTML(data);
       $('.chat-main__message-lists').append(html);
       $('.chat-main__message-lists').animate({ scrollTop: $('.chat-main__message-lists')[0].scrollHeight });
-      formReset();
     })
     .fail(function() {
       alert("メッセージ送信に失敗しました");
+    })
+    .always(function() {
       formReset();
     });
   })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,69 @@
+$(function(){
+  function buildHTML(message){
+    if (message.image){
+      var html = `<div class="chat-main__message-lists__message">
+                    <div class="chat-main__message-lists__message__info">
+                      <div class="chat-main__message-lists__message__info__talker">
+                        ${message.user_name}
+                      </div>
+                      <div class="chat-main__message-lists__message__info__date">
+                        ${message.created_at}
+                      </div>
+                    </div>
+                    <div class="chat-main__message-list__message__text">
+                      <div class="chat-main__message-list__message__text__content">
+                        ${message.content}
+                      </div>
+                      <img class="chat-main__message-list__message__text__image" src=${message.image}>
+                    </div>
+                  </div>`
+      return html;
+    } else {
+      var html = `<div class="chat-main__message-lists__message">
+                    <div class="chat-main__message-lists__message__info">
+                      <div class="chat-main__message-lists__message__info__talker">
+                        ${message.user_name}
+                      </div>
+                      <div class="chat-main__message-lists__message__info__date">
+                        ${message.created_at}
+                      </div>
+                    </div>
+                    <div class="chat-main__message-list__message__text">
+                      <div class="chat-main__message-list__message__text__content">
+                        ${message.content}
+                      </div>
+                    </div>
+                  </div>`
+      return html;
+    };
+  }
+
+  function formReset(){
+    $('form')[0].reset();
+    $('.chat-main__message-form__new-message__send-btn__btn').prop('disabled', false);
+  }
+
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: 'POST',
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.chat-main__message-lists').append(html);
+      $('.chat-main__message-lists').animate({ scrollTop: $('.chat-main__message-lists')[0].scrollHeight });
+      formReset();
+    })
+    .fail(function() {
+      alert("メッセージ送信に失敗しました");
+      formReset();
+    });
+  })
+});

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -8,7 +8,6 @@ class MessagesController < ApplicationController
 
   def create
     @message = @group.messages.new(message_params)
-    # binding.pry
     if @message.save
       respond_to do |format|
         format.json

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,7 +10,9 @@ class MessagesController < ApplicationController
     @message = @group.messages.new(message_params)
     # binding.pry
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,6 @@
     %meta{content: "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     = stylesheet_link_tag    'application', media: 'all'
     = javascript_include_tag 'application'
   %body

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,10 @@
     %meta{content: "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,9 @@ Bundler.require(*Rails.groups)
 
 module ChatSpace
   class Application < Rails::Application
+
+    config.time_zone = 'Tokyo'
+
     config.generators do |g|
       g.stylesheets false
       g.javascripts false


### PR DESCRIPTION
# What
チャット送信を非同期通信にする。

# Why
チャットを送信するたびに画面がリロードしなくても良いように
JavaScriptを使用して非同期通信を実現するため。